### PR TITLE
Put a Job Id to the worker so it logs unique hash

### DIFF
--- a/spec/gitlab_post_receive_spec.rb
+++ b/spec/gitlab_post_receive_spec.rb
@@ -50,7 +50,7 @@ describe GitlabPostReceive do
       expect(gitlab_post_receive).to receive(:system).with(
         *[
           *%w(env -i redis-cli rpush resque:gitlab:queue:post_receive), 
-          %Q/{"class":"PostReceive","args":["#{repo_path}","#{actor}",#{base64_changes.inspect}]}/,
+          %Q/{"class":"PostReceive","args":["#{repo_path}","#{actor}",#{base64_changes.inspect}],"jid":"#{gitlab_post_receive.jid}"}/,
           { err: "/dev/null", out: "/dev/null" }
         ]
       ).and_return(true)


### PR DESCRIPTION
This way sidekiq can Log a unique JID in the sidekiq.log for PostReceive.
That way when parsing the logs I know this belongs to this job (I'm doing a elasticsearch parse of the logs and having a unique id helps me index the results of the worker properly)
